### PR TITLE
Feat/account management

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -4,12 +4,14 @@ const THREEID_CONNECT_URL = 'http://localhost:30001'
 import { DID } from 'dids'
 
 const threeIdConnect = new ThreeIdConnect(THREEID_CONNECT_URL)
+let ethAddress
 
 const authenticate = async () => {
   const ethProvider = await web3Modal.connect()
   const addresses = await ethProvider.enable()
 
-  const authProvider = new EthereumAuthProvider(ethProvider, addresses[0])
+  let ethAddress = addresses[0]
+  const authProvider = new EthereumAuthProvider(ethProvider, ethAddress)
   await threeIdConnect.connect(authProvider)
 
   const didProvider = await threeIdConnect.getDidProvider()
@@ -22,4 +24,28 @@ const authenticate = async () => {
   console.log(jws)
 }
 
+// TODO must connect first 
+let accountslist
+const accounts = async () => {
+  accountslist = await threeIdConnect.accounts()
+  console.log(accounts)
+
+
+}
+
+const create = async () => {
+  const res = await threeIdConnect.createAccount()
+  console.log(res)
+}
+
+const link = async () => {
+  const res = await threeIdConnect.createAndLink(accountslist[0])
+  console.log(res)
+}
+
+
+
 bauth.addEventListener('click', authenticate)
+baccounts.addEventListener('click', accounts)
+bcreate.addEventListener('click', create)
+blink.addEventListener('click', link)

--- a/example/index.html
+++ b/example/index.html
@@ -22,6 +22,9 @@
   <body>
     <div id="root"></div>
     <button id="bauth" type="button" class="btn btn-primary" style="margin: 50px 100px;">Connect</button>
+    <button id="baccounts" type="button" class="btn btn-primary" style="margin: 50px 100px;">Accounts</button>
+    <button id="bcreate" type="button" class="btn btn-primary" style="margin: 50px 100px;">Create</button>
+    <button id="blink" type="button" class="btn btn-primary" style="margin: 50px 100px;">Link</button>
   </body>
 
   <script type="text/javascript" src="build.js"></script>

--- a/iframe/html/template.js
+++ b/iframe/html/template.js
@@ -54,17 +54,23 @@ const content = (data) => {
   if (data.request.type === 'account') {
     return `You have not used this account with 3id, do you want to link this account?`
   }
+  if (data.request.type === 'create') {
+    return `Do you want to create a new account?`
+  }
+  if (data.request.type === 'link') {
+    return `Do you want to link this account to ${data.request.baseDid.substring(0,18)}... ?`
+  }
 }
 
 const actions = (data) => {
-  if (data.request.type === 'authenticate') {
+  if (data.request.type === 'authenticate' || data.request.type === 'create') {
     return `
       <button id='accept' class='${style.primaryButton}' ${data.error ? 'style="display:none;"' : ''} >
         Continue
       </button>
     `
   }
-  if (data.request.type === 'account') {
+  if (data.request.type === 'account' || data.request.type === 'link') {
     return `
       <button id='accept' style='margin-right:8%;' class='${style.primaryButtonHalf}' ${data.error ? 'style="display:none;"' : ''} >
         Yes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "3id-connect",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3id-connect",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Account management for 3ID",
   "main": "lib/index.js",
   "files": [

--- a/src/didProviderProxy.js
+++ b/src/didProviderProxy.js
@@ -5,9 +5,8 @@ import { caller } from 'postmsg-rpc'
  *  relay request to iframe (rpc server)
  */
 class DidProviderProxy {
-  constructor (postMessage, accountId) {
-    this.postMessage = postMessage
-    this.sendRPC = caller('send', {postMessage: this.postMessage})
+  constructor (provider, accountId) {
+    this.provider = provider
     this.accountId = accountId
   }
 
@@ -17,8 +16,7 @@ class DidProviderProxy {
 
   async send (msg, origin) {
     msg.params = Object.assign({}, msg.params, { accountId: this.accountId })
-    const res = await this.sendRPC(msg)
-    return JSON.parse(res)
+    return this.provider.send(msg)
   }
 }
 


### PR DESCRIPTION
WIP, dont review yet

Functions may change a bit, most visuals not there, mostly need better error handling for account management functions, and definitely more testing. Account management functions are not limited to any domains at moment. 

released @next and at 3idconnect.org

Following changes:

Can connect with or without authprovider, and set authprovider after, or change authprovider (ie change account id/address)

```js
await threeIdConnect.connect()
threeIdConnect.setAuthProvider(authProvider)
```

Following account management functions added:

```js
// accounts available in 3id-connect window and known links
const accounts = await threeIdConnect.accounts()
// { 
//    'did:3:kjzl6cwe1jw145rgc4....': ["0x0ff153...79d2234@eip155:1", "0x3f0bb624...382b61d@eip155:1"],
//    'did:3:kjzl6cwe1jw147vuvd....': [""0x48ecdd7e...590c40c@eip155:1"]
// }
```

```js
// similar to auth, but explicitly prompts user to just create account (not create or link prompt) 

await threeIdConnect.createAccount()

// returns true if successful, will throw some errors but needs better error handling still 
```

```js
// add and link current authprovider/id to existing given did (already exist in iframe), will prompt user to confirm link

await threeIdConnect.addAuthAndLink(did)

// returns true if successful, will throw some errors but needs better error handling still 
```
