### PR TITLE
Displaying shortened DIDs crops the last character

### DIFF
--- a/apps/management/src/data/idx.ts
+++ b/apps/management/src/data/idx.ts
@@ -22,11 +22,11 @@ export async function loadProfile(did: string): Promise<BasicProfile | null> {
 }
 
 export function formatDID(did: string): string {
-  return did.length <= 20 ? did : `${did.slice(0, 10)}...${did.slice(-6, -1)}`
+  return did.length <= 20 ? did : `${did.slice(0, 10)}…${did.slice(-5)}`
 }
 
 export function longFormatDID(did: string): string {
-  return `${did.slice(0, 10)}...${did.slice(-10, -1)}`
+  return `${did.slice(0, 10)}…${did.slice(-9)}`
 }
 
 function selectCover(


### PR DESCRIPTION
`formatDID` & `longFormatDID` currently are of the format `${did.slice(0, 10)}...${did.slice(-6, -1)}`. `slice(-6, -1)` doesn't include the last character in the output.

This pull request fixes the `slice`, and uses the unicode ellipsis which takes up a fraction less room.