### PR TITLE
fix: ensure process is not undefined before referencing it

### DIFF
--- a/packages/connect/src/threeIdConnect.ts
+++ b/packages/connect/src/threeIdConnect.ts
@@ -26,9 +26,11 @@ const BASE_MAIN_URL = 'https://app.3idconnect.org'
 const BASE_LOCAL_URL = `http://localhost:30001`
 const DEFAULT_MANAGE_PATH = `/management/index.html`
 
-const CONNECT_IFRAME_URL = process.env.CONNECT_IFRAME_URL || BASE_CLAY_URL
-const CONNECT_MANAGE_URL =
-  process.env.CONNECT_MANAGE_URL || `${BASE_CLAY_URL}/management/index.html`
+let CONNECT_IFRAME_URL = BASE_CLAY_URL;
+let CONNECT_MANAGE_URL = `${BASE_CLAY_URL}/management/index.html`;
+
+typeof process !== 'undefined' && (CONNECT_IFRAME_URL = process.env.CONNECT_IFRAME_URL || BASE_CLAY_URL);
+typeof process !== 'undefined' && (CONNECT_MANAGE_URL = process.env.CONNECT_MANAGE_URL || `${BASE_CLAY_URL}/management/index.html`);
 
 const networkConfig = (base:string):NetworkConfig => {
   return {

--- a/packages/manager/src/manager.ts
+++ b/packages/manager/src/manager.ts
@@ -17,8 +17,11 @@ import { Migrate3IDV0, legacyDIDLinkExist, get3BoxLinkProof } from './migration'
 import type { AuthConfig, SeedConfig } from './types'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
 
-const CERAMIC_API = process.env.CERAMIC_API || 'https://ceramic-clay.3boxlabs.com'
-const DID_MIGRATION = process.env.MIGRATION ? process.env.MIGRATION === 'true' : true // default true
+let CERAMIC_API = 'https://ceramic-clay.3boxlabs.com';
+let DID_MIGRATION = true;
+
+typeof process !== 'undefined' && (CERAMIC_API = process.env.CERAMIC_API || 'https://ceramic-clay.3boxlabs.com');
+typeof process !== 'undefined' && (DID_MIGRATION = process.env.MIGRATION ? process.env.MIGRATION === 'true' : true);
 
 export class Manager {
   authProvider: AuthProvider

--- a/packages/manager/src/migration.ts
+++ b/packages/manager/src/migration.ts
@@ -15,7 +15,8 @@ import { fetchJson, jwtDecode } from './utils'
 
 const LEGACY_ADDRESS_SERVER = 'https://beta.3box.io/address-server'
 const THREEBOX_PROFILE_API = 'https://ipfs.3box.io'
-const VERIFICATION_SERVICE = process.env.VERIFICATION_SERVICE || 'https://verifications-clay.3boxlabs.com'
+let VERIFICATION_SERVICE = 'https://verifications-clay.3boxlabs.com';
+typeof process !== 'undefined' && (VERIFICATION_SERVICE = process.env.VERIFICATION_SERVICE || 'https://verifications-clay.3boxlabs.com');
 
 export class Migrate3IDV0 {
   private idx: IDX

--- a/packages/window-auth-provider/src/index.ts
+++ b/packages/window-auth-provider/src/index.ts
@@ -5,7 +5,9 @@ import { AccountID } from 'caip'
 import type { RPCClient } from 'rpc-utils'
 import type { Observable } from 'rxjs'
 
-const NAMESPACE = process.env.NAMESPACE || '3id-connect-authprovider'
+let NAMESPACE = '3id-connect-authprovider';
+
+typeof process !== 'undefined' && (NAMESPACE = process.env.NAMESPACE || '3id-connect-authprovider');
 
 export type AuthProviderMethods = {
   accountId: { result: string }


### PR DESCRIPTION
Some frameworks like Svelte throw an error when importing this package because `process` is undefined.

By only referring to `process` it when it is not of type `undefined`, this can be avoided.