### PR TITLE
fix(connect): unsubscribe from previous authProvider

### DIFF
--- a/apps/iframe/src/connectService.ts
+++ b/apps/iframe/src/connectService.ts
@@ -10,11 +10,10 @@ import ThreeIdProvider from '3id-did-provider'
 import type { DIDMethodName, DIDProvider, DIDProviderMethods, DIDRequest, DIDResponse } from 'dids'
 import type { RPCErrorObject, RPCRequest, RPCResponse, RPCResultResponse } from 'rpc-utils'
 import Url from 'url-parse'
-import { UIProvider, ThreeIDManagerUI } from '../../../packages/ui-provider/src/index'
+import { UIProvider, ThreeIDManagerUI, AuthParams } from '../../../packages/ui-provider/src/index'
 
 import { IframeService } from './iframeService'
 import type {
-  UserAuthenticateRequest,
   UserRequestCancel,
 } from './types'
 import { rpcError } from './utils'
@@ -83,7 +82,7 @@ export class ConnectService extends IframeService<DIDProviderMethods> {
       await this.userPermissionRequest(authReq, domain)
     }
 
-    //TODO if not exist locally and not in network, then skip first modal aboev, and merge below with create 
+    //TODO if not exist locally and not in network, then skip first modal aboev, and merge below with create
 
     let legacyDid = await legacyDidPromise
     let muportDid
@@ -104,7 +103,7 @@ export class ConnectService extends IframeService<DIDProviderMethods> {
       willFail = await willMigrationFail(accountId, legacyDid)
       if (willFail) legacyDid = null
     }
-    
+
     // If new account (and not migration), ask user to link or create
     if (!(legacyDid || muportDid || willFail) && newAccount) {
       const createNew = (await this.uiManager.promptAccount()).createNew
@@ -245,7 +244,7 @@ export class ConnectService extends IframeService<DIDProviderMethods> {
     req: RPCRequest<DIDProviderMethods, K>,
     origin?: string | null,
     did?: string
-  ): UserAuthenticateRequest | null {
+  ): AuthParams | null {
     assert.isDefined(req.params, 'Request parameters must be provided')
     const params = req.params as DIDProviderMethods[K]['params'] & { paths?: Array<string> }
 

--- a/packages/connect/src/threeIdConnect.ts
+++ b/packages/connect/src/threeIdConnect.ts
@@ -30,7 +30,7 @@ const CONNECT_IFRAME_URL = process.env.CONNECT_IFRAME_URL || BASE_CLAY_URL
 const CONNECT_MANAGE_URL =
   process.env.CONNECT_MANAGE_URL || `${BASE_CLAY_URL}/management/index.html`
 
-const networkConfig = (base:string):NetworkConfig => {
+const networkConfig = (base: string): NetworkConfig => {
   return {
     connect_iframe: base,
     manage_iframe: `${base}${DEFAULT_MANAGE_PATH}`
@@ -116,6 +116,9 @@ export class ThreeIdConnect {
   }
 
   async connect(provider: AuthProvider): Promise<void> {
+    if (this._authProviderSubscription) {
+      this._authProviderSubscription.unsubscribe()
+    }
     if (provider) {
       await this.setAuthProvider(provider)
     }
@@ -123,7 +126,7 @@ export class ThreeIdConnect {
     this.postMessage = this.iframe.contentWindow!.postMessage.bind(this.iframe.contentWindow)
 
     // TODO: this should only be set if there is a provider injected, also need to stop current subscription
-    createAuthProviderServer(provider).subscribe()
+    this._authProviderSubscription = createAuthProviderServer(provider).subscribe()
     createDisplayConnectServerRPC(this.iframe).subscribe()
     createDisplayManageServerRPC(this.manageUrl).subscribe()
 


### PR DESCRIPTION
This PR fixes case where changing accounts will keep previous authProvider active.