### PR TITLE
fix: ui modal header did handler

### DIFF
--- a/apps/management/src/modal/components/HeaderContainer.tsx
+++ b/apps/management/src/modal/components/HeaderContainer.tsx
@@ -18,7 +18,8 @@ const headerData = (req: RequestState) => {
   }
 
   let headerStr
-  if (req.type === 'prompt_authenticate') {
+  // @ts-ignore
+  if (req.type === 'prompt_authenticate' && req.params?.did) {
     // @ts-ignore
     headerStr = didShorten(req.params.did)
   } else if (req.type === 'prompt_migration') {


### PR DESCRIPTION
Minimal fix before weekend, to release, but could revisit the following changes 
- better dev build env, ie iframe/modal dev build with sourcemaps, reload etc 
- most these requests could be better typed now (after last manager improvements), lots of ts-ignore from older code will result in simple uncaught errors like these
