### PR TITLE
Swap CTA priority for new accounts

### DIFF
--- a/apps/management/src/modal/components/Actions.tsx
+++ b/apps/management/src/modal/components/Actions.tsx
@@ -46,7 +46,7 @@ export default function Actions() {
 		return(
 			<div className={styles.actions}>
 				<PrimaryButton label="Create new account" onClick={clickTrue} status={reqState.status} loadingLabel="Sign messages in your wallet"/>
-				<SecondaryButton label="Link existing account" onClick={clickFalse} status={reqState.status} loadingLabel="Sign two messages in your wallet"/>
+				<SecondaryButton label="Link existing account" onClick={clickFalse} status={reqState.status} loadingLabel=" "/>
 			</div>
 		)
   } else if (reqState?.type === 'inform_error') {

--- a/apps/management/src/modal/components/Actions.tsx
+++ b/apps/management/src/modal/components/Actions.tsx
@@ -45,8 +45,8 @@ export default function Actions() {
 	} else if (reqState?.type === 'prompt_account') {
 		return(
 			<div className={styles.actions}>
-				<PrimaryButton label="Link existing account" onClick={clickFalse} status={reqState.status} loadingLabel="Sign two messages in your wallet"/>
-				<SecondaryButton label="Create new account" onClick={clickTrue} status={reqState.status} loadingLabel=" "/>
+				<PrimaryButton label="Create new account" onClick={clickTrue} status={reqState.status} loadingLabel="Sign messages in your wallet"/>
+				<SecondaryButton label="Link existing account" onClick={clickFalse} status={reqState.status} loadingLabel="Sign two messages in your wallet"/>
 			</div>
 		)
   } else if (reqState?.type === 'inform_error') {


### PR DESCRIPTION
# Reorder CTAs when a wallet address doesn't have an account

## Description

When a user's wallet doesn't have an account, the primary CTA is to link an existing account, rather than create a new account. This creates confusion as new users who do not already have an account often choose the wrong action.

This PR reorders the links, so that the Primary CTA is to link a new account.


https://user-images.githubusercontent.com/4670881/186469297-3e63ba58-2615-4af4-be27-6a4d53c5d63b.mov


https://user-images.githubusercontent.com/4670881/186469311-c95d77ee-50f0-4200-8b6d-10bdbd5344f2.mov

